### PR TITLE
Sprint 4: sharding, replication, cache, and architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,68 @@
-# pymongo-api
+# architecture-black_friday
 
-## Как запустить
+Репозиторий с решением проектной работы 4 спринта.
 
-Запускаем mongodb и приложение
+## Структура
 
-```shell
-docker compose up -d
+- `mongo-sharding` — шардирование (2 шарда)
+- `mongo-sharding-repl` — шардирование + репликация (по 3 реплики на каждый шард)
+- `sharding-repl-cache` — финальный стенд: шардирование + репликация + Redis cache
+- `architecture-final.drawio` — итоговая схема (включает шардирование, репликацию, кеш, API Gateway, Consul, CDN)
+
+## Что проверять ревьюеру
+
+Основная директория для проверки заданий 2, 3, 4:
+
+```bash
+cd sharding-repl-cache
 ```
 
-Заполняем mongodb данными
+## Запуск финального стенда
 
-```shell
+```bash
+docker compose up -d
+chmod +x scripts/init-repl-sharding.sh scripts/mongo-init.sh
+./scripts/init-repl-sharding.sh
 ./scripts/mongo-init.sh
 ```
 
-## Как проверить
+## Проверки
 
-### Если вы запускаете проект на локальной машине
+Статус сервисов:
 
-Откройте в браузере http://localhost:8080
-
-### Если вы запускаете проект на предоставленной виртуальной машине
-
-Узнать белый ip виртуальной машины
-
-```shell
-curl --silent http://ifconfig.me
+```bash
+docker compose ps
 ```
 
-Откройте в браузере http://<ip виртуальной машины>:8080
+Общее количество документов (должно быть >= 1000):
 
-## Доступные эндпоинты
+```bash
+docker compose exec -T mongos mongosh --port 27017 --quiet <<'EOF'
+use somedb
+db.helloDoc.countDocuments()
+EOF
+```
 
-Список доступных эндпоинтов, swagger http://<ip виртуальной машины>:8080/docs
+Проверка шардирования и реплик:
+
+```bash
+docker compose exec -T mongos mongosh --port 27017 --quiet <<'EOF'
+sh.status()
+EOF
+```
+
+Проверка кеша (второй и следующие запросы < 100ms):
+
+```bash
+time curl -s http://localhost:8080/helloDoc/users > /dev/null
+time curl -s http://localhost:8080/helloDoc/users > /dev/null
+```
+
+Проверка API:
+
+- `http://localhost:8080`
+- `http://localhost:8080/docs`
+
+## Используемый образ приложения
+
+Во всех новых стендах используется `kazhem/pymongo_api:1.0.0`.

--- a/architecture-final.drawio
+++ b/architecture-final.drawio
@@ -1,0 +1,50 @@
+<mxfile host="app.diagrams.net" modified="2026-05-08T15:30:00.000Z" agent="Codex" version="24.7.0">
+  <diagram id="final-arch" name="Page-1">
+    <mxGraphModel dx="1400" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="2200" pageHeight="1400" math="0" shadow="0">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="u1" value="Users (Region 1)" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1"><mxGeometry x="20" y="80" width="130" height="50" as="geometry"/></mxCell>
+        <mxCell id="u2" value="Users (Region 2)" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1"><mxGeometry x="20" y="170" width="130" height="50" as="geometry"/></mxCell>
+        <mxCell id="cdn1" value="CDN (Region 1)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;" vertex="1" parent="1"><mxGeometry x="180" y="80" width="140" height="50" as="geometry"/></mxCell>
+        <mxCell id="cdn2" value="CDN (Region 2)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;" vertex="1" parent="1"><mxGeometry x="180" y="170" width="140" height="50" as="geometry"/></mxCell>
+        <mxCell id="gateway" value="API Gateway" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;" vertex="1" parent="1"><mxGeometry x="380" y="120" width="140" height="60" as="geometry"/></mxCell>
+        <mxCell id="consul" value="Consul" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;" vertex="1" parent="1"><mxGeometry x="380" y="220" width="140" height="60" as="geometry"/></mxCell>
+        <mxCell id="app1" value="pymongo-api-1" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1"><mxGeometry x="580" y="70" width="140" height="50" as="geometry"/></mxCell>
+        <mxCell id="app2" value="pymongo-api-2" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1"><mxGeometry x="580" y="140" width="140" height="50" as="geometry"/></mxCell>
+        <mxCell id="app3" value="pymongo-api-3" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1"><mxGeometry x="580" y="210" width="140" height="50" as="geometry"/></mxCell>
+        <mxCell id="redis" value="redis" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;" vertex="1" parent="1"><mxGeometry x="770" y="130" width="110" height="60" as="geometry"/></mxCell>
+        <mxCell id="mongos" value="mongos" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;" vertex="1" parent="1"><mxGeometry x="930" y="130" width="110" height="60" as="geometry"/></mxCell>
+        <mxCell id="cfg" value="configSrv (configReplSet)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;" vertex="1" parent="1"><mxGeometry x="1080" y="20" width="170" height="70" as="geometry"/></mxCell>
+        <mxCell id="s1label" value="ReplicaSet: shard1ReplSet" style="rounded=1;whiteSpace=wrap;html=1;strokeColor=#6c8ebf;" vertex="1" parent="1"><mxGeometry x="1060" y="120" width="330" height="30" as="geometry"/></mxCell>
+        <mxCell id="s1a" value="shard1-1 (primary)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;" vertex="1" parent="1"><mxGeometry x="1060" y="170" width="100" height="70" as="geometry"/></mxCell>
+        <mxCell id="s1b" value="shard1-2" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;" vertex="1" parent="1"><mxGeometry x="1170" y="170" width="100" height="70" as="geometry"/></mxCell>
+        <mxCell id="s1c" value="shard1-3" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;" vertex="1" parent="1"><mxGeometry x="1280" y="170" width="100" height="70" as="geometry"/></mxCell>
+        <mxCell id="s2label" value="ReplicaSet: shard2ReplSet" style="rounded=1;whiteSpace=wrap;html=1;strokeColor=#b85450;" vertex="1" parent="1"><mxGeometry x="1060" y="260" width="330" height="30" as="geometry"/></mxCell>
+        <mxCell id="s2a" value="shard2-1 (primary)" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;" vertex="1" parent="1"><mxGeometry x="1060" y="310" width="100" height="70" as="geometry"/></mxCell>
+        <mxCell id="s2b" value="shard2-2" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;" vertex="1" parent="1"><mxGeometry x="1170" y="310" width="100" height="70" as="geometry"/></mxCell>
+        <mxCell id="s2c" value="shard2-3" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;" vertex="1" parent="1"><mxGeometry x="1280" y="310" width="100" height="70" as="geometry"/></mxCell>
+        <mxCell id="origin" value="Static content origin" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1"><mxGeometry x="380" y="20" width="140" height="50" as="geometry"/></mxCell>
+
+        <mxCell id="e1" style="endArrow=classic;html=1;" edge="1" parent="1" source="u1" target="cdn1"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e2" style="endArrow=classic;html=1;" edge="1" parent="1" source="u2" target="cdn2"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e3" style="endArrow=classic;html=1;" edge="1" parent="1" source="cdn1" target="gateway"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e4" style="endArrow=classic;html=1;" edge="1" parent="1" source="cdn2" target="gateway"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e5" style="endArrow=classic;html=1;" edge="1" parent="1" source="origin" target="cdn1"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e6" style="endArrow=classic;html=1;" edge="1" parent="1" source="origin" target="cdn2"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e7" style="endArrow=classic;html=1;" edge="1" parent="1" source="gateway" target="app1"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e8" style="endArrow=classic;html=1;" edge="1" parent="1" source="gateway" target="app2"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e9" style="endArrow=classic;html=1;" edge="1" parent="1" source="gateway" target="app3"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e10" value="service registration" style="endArrow=classic;html=1;dashed=1;" edge="1" parent="1" source="app1" target="consul"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e11" style="endArrow=classic;html=1;dashed=1;" edge="1" parent="1" source="app2" target="consul"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e12" style="endArrow=classic;html=1;dashed=1;" edge="1" parent="1" source="app3" target="consul"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e13" value="service discovery" style="endArrow=classic;html=1;dashed=1;" edge="1" parent="1" source="gateway" target="consul"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e14" style="endArrow=classic;html=1;" edge="1" parent="1" source="app2" target="redis"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e15" style="endArrow=classic;html=1;" edge="1" parent="1" source="app2" target="mongos"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e16" style="endArrow=classic;html=1;" edge="1" parent="1" source="mongos" target="cfg"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e17" style="endArrow=classic;html=1;" edge="1" parent="1" source="mongos" target="s1a"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e18" style="endArrow=classic;html=1;" edge="1" parent="1" source="mongos" target="s2a"><mxGeometry relative="1" as="geometry"/></mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/mongo-sharding-repl/README.md
+++ b/mongo-sharding-repl/README.md
@@ -1,0 +1,54 @@
+# mongo-sharding-repl
+
+Стенд с шардированием и репликацией (по 3 реплики на каждый шард).
+
+## Запуск
+
+```bash
+docker compose up -d
+```
+
+## Инициализация шардирования и репликации
+
+```bash
+chmod +x scripts/init-repl-sharding.sh scripts/mongo-init.sh
+./scripts/init-repl-sharding.sh
+./scripts/mongo-init.sh
+```
+
+## Проверка
+
+Общее число документов:
+
+```bash
+docker compose exec -T mongos mongosh --port 27017 --quiet <<'EOF'
+use somedb
+db.helloDoc.countDocuments()
+EOF
+```
+
+Информация по шардам:
+
+```bash
+docker compose exec -T mongos mongosh --port 27017 --quiet <<'EOF'
+sh.status()
+EOF
+```
+
+Проверка числа реплик на `shard1`:
+
+```bash
+docker compose exec -T shard1-1 mongosh --port 27018 --quiet <<'EOF'
+rs.status().members.length
+EOF
+```
+
+Проверка числа реплик на `shard2`:
+
+```bash
+docker compose exec -T shard2-1 mongosh --port 27018 --quiet <<'EOF'
+rs.status().members.length
+EOF
+```
+
+Приложение доступно на `http://localhost:8080`, документация на `http://localhost:8080/docs`.

--- a/mongo-sharding-repl/api_app/Dockerfile
+++ b/mongo-sharding-repl/api_app/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12.1-slim
+WORKDIR /app
+EXPOSE 8080
+COPY requirements.txt ./
+# Устанавливаем зависимости python не пересобирая их
+RUN pip install --no-cache --no-cache-dir -r requirements.txt
+# Копирование кода приложения
+COPY app.py /app/
+ENTRYPOINT ["uvicorn"]
+CMD ["app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/mongo-sharding-repl/api_app/app.py
+++ b/mongo-sharding-repl/api_app/app.py
@@ -1,0 +1,191 @@
+import json
+import logging
+import os
+import time
+from typing import List, Optional
+
+import motor.motor_asyncio
+from bson import ObjectId
+from fastapi import Body, FastAPI, HTTPException, status
+from fastapi_cache import FastAPICache
+from fastapi_cache.backends.redis import RedisBackend
+from fastapi_cache.decorator import cache
+from logmiddleware import RouterLoggingMiddleware, logging_config
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic.functional_validators import BeforeValidator
+from pymongo import errors
+from redis import asyncio as aioredis
+from typing_extensions import Annotated
+
+# Configure JSON logging
+logging.config.dictConfig(logging_config)
+logger = logging.getLogger(__name__)
+
+app = FastAPI()
+app.add_middleware(
+    RouterLoggingMiddleware,
+    logger=logger,
+)
+
+DATABASE_URL = os.environ["MONGODB_URL"]
+DATABASE_NAME = os.environ["MONGODB_DATABASE_NAME"]
+REDIS_URL = os.getenv("REDIS_URL", None)
+
+
+def nocache(*args, **kwargs):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+if REDIS_URL:
+    cache = cache
+else:
+    cache = nocache
+
+
+client = motor.motor_asyncio.AsyncIOMotorClient(DATABASE_URL)
+db = client[DATABASE_NAME]
+
+# Represents an ObjectId field in the database.
+# It will be represented as a `str` on the model so that it can be serialized to JSON.
+PyObjectId = Annotated[str, BeforeValidator(str)]
+
+
+@app.on_event("startup")
+async def startup():
+    if REDIS_URL:
+        redis = aioredis.from_url(REDIS_URL, encoding="utf8", decode_responses=True)
+        FastAPICache.init(RedisBackend(redis), prefix="api:cache")
+
+
+class UserModel(BaseModel):
+    """
+    Container for a single user record.
+    """
+
+    id: Optional[PyObjectId] = Field(alias="_id", default=None)
+    age: int = Field(...)
+    name: str = Field(...)
+
+
+class UserCollection(BaseModel):
+    """
+    A container holding a list of `UserModel` instances.
+    """
+
+    users: List[UserModel]
+
+
+@app.get("/")
+async def root():
+    collection_names = await db.list_collection_names()
+    collections = {}
+    for collection_name in collection_names:
+        collection = db.get_collection(collection_name)
+        collections[collection_name] = {
+            "documents_count": await collection.count_documents({})
+        }
+    try:
+        replica_status = await client.admin.command("replSetGetStatus")
+        replica_status = json.dumps(replica_status, indent=2, default=str)
+    except errors.OperationFailure:
+        replica_status = "No Replicas"
+
+    topology_description = client.topology_description
+    read_preference = client.client_options.read_preference
+    topology_type = topology_description.topology_type_name
+    replicaset_name = topology_description.replica_set_name
+
+    shards = None
+    if topology_type == "Sharded":
+        shards_list = await client.admin.command("listShards")
+        shards = {}
+        for shard in shards_list.get("shards", {}):
+            shards[shard["_id"]] = shard["host"]
+
+    cache_enabled = False
+    if REDIS_URL:
+        cache_enabled = FastAPICache.get_enable()
+
+    return {
+        "mongo_topology_type": topology_type,
+        "mongo_replicaset_name": replicaset_name,
+        "mongo_db": DATABASE_NAME,
+        "read_preference": str(read_preference),
+        "mongo_nodes": client.nodes,
+        "mongo_primary_host": client.primary,
+        "mongo_secondary_hosts": client.secondaries,
+        "mongo_is_primary": client.is_primary,
+        "mongo_is_mongos": client.is_mongos,
+        "collections": collections,
+        "shards": shards,
+        "cache_enabled": cache_enabled,
+        "status": "OK",
+    }
+
+
+@app.get("/{collection_name}/count")
+async def collection_count(collection_name: str):
+    collection = db.get_collection(collection_name)
+    items_count = await collection.count_documents({})
+    # status = await client.admin.command('replSetGetStatus')
+    # import ipdb; ipdb.set_trace()
+    return {"status": "OK", "mongo_db": DATABASE_NAME, "items_count": items_count}
+
+
+@app.get(
+    "/{collection_name}/users",
+    response_description="List all users",
+    response_model=UserCollection,
+    response_model_by_alias=False,
+)
+@cache(expire=60 * 1)
+async def list_users(collection_name: str):
+    """
+    List all of the user data in the database.
+    The response is unpaginated and limited to 1000 results.
+    """
+    time.sleep(1)
+    collection = db.get_collection(collection_name)
+    return UserCollection(users=await collection.find().to_list(1000))
+
+
+@app.get(
+    "/{collection_name}/users/{name}",
+    response_description="Get a single user",
+    response_model=UserModel,
+    response_model_by_alias=False,
+)
+async def show_user(collection_name: str, name: str):
+    """
+    Get the record for a specific user, looked up by `name`.
+    """
+
+    collection = db.get_collection(collection_name)
+    if (user := await collection.find_one({"name": name})) is not None:
+        return user
+
+    raise HTTPException(status_code=404, detail=f"User {name} not found")
+
+
+@app.post(
+    "/{collection_name}/users",
+    response_description="Add new user",
+    response_model=UserModel,
+    status_code=status.HTTP_201_CREATED,
+    response_model_by_alias=False,
+)
+async def create_user(collection_name: str, user: UserModel = Body(...)):
+    """
+    Insert a new user record.
+
+    A unique `id` will be created and provided in the response.
+    """
+    collection = db.get_collection(collection_name)
+    new_user = await collection.insert_one(
+        user.model_dump(by_alias=True, exclude=["id"])
+    )
+    created_user = await collection.find_one({"_id": new_user.inserted_id})
+    return created_user

--- a/mongo-sharding-repl/api_app/requirements.txt
+++ b/mongo-sharding-repl/api_app/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.110.2
+uvicorn[standard]==0.29.0
+motor==3.5.3
+redis==4.4.2
+fastapi-cache2==0.2.0
+logmiddleware==0.0.4

--- a/mongo-sharding-repl/compose.yaml
+++ b/mongo-sharding-repl/compose.yaml
@@ -1,0 +1,86 @@
+name: mongo-sharding-repl
+
+services:
+  configsvr:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: configsvr
+    command: mongod --configsvr --replSet configReplSet --port 27019
+    volumes:
+      - configsvr_data:/data/db
+
+  shard1-1:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: shard1-1
+    command: mongod --shardsvr --replSet shard1ReplSet --port 27018
+    volumes:
+      - shard1_1_data:/data/db
+
+  shard1-2:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: shard1-2
+    command: mongod --shardsvr --replSet shard1ReplSet --port 27018
+    volumes:
+      - shard1_2_data:/data/db
+
+  shard1-3:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: shard1-3
+    command: mongod --shardsvr --replSet shard1ReplSet --port 27018
+    volumes:
+      - shard1_3_data:/data/db
+
+  shard2-1:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: shard2-1
+    command: mongod --shardsvr --replSet shard2ReplSet --port 27018
+    volumes:
+      - shard2_1_data:/data/db
+
+  shard2-2:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: shard2-2
+    command: mongod --shardsvr --replSet shard2ReplSet --port 27018
+    volumes:
+      - shard2_2_data:/data/db
+
+  shard2-3:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: shard2-3
+    command: mongod --shardsvr --replSet shard2ReplSet --port 27018
+    volumes:
+      - shard2_3_data:/data/db
+
+  mongos:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: mongos
+    command: mongos --configdb configReplSet/configsvr:27019 --bind_ip_all --port 27017
+    depends_on:
+      - configsvr
+      - shard1-1
+      - shard1-2
+      - shard1-3
+      - shard2-1
+      - shard2-2
+      - shard2-3
+    ports:
+      - "27017:27017"
+
+  pymongo_api:
+    image: kazhem/pymongo_api:1.0.0
+    container_name: pymongo_api
+    depends_on:
+      - mongos
+    ports:
+      - "8080:8080"
+    environment:
+      MONGODB_URL: "mongodb://mongos:27017"
+      MONGODB_DATABASE_NAME: "somedb"
+
+volumes:
+  configsvr_data:
+  shard1_1_data:
+  shard1_2_data:
+  shard1_3_data:
+  shard2_1_data:
+  shard2_2_data:
+  shard2_3_data:

--- a/mongo-sharding-repl/scripts/init-repl-sharding.sh
+++ b/mongo-sharding-repl/scripts/init-repl-sharding.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+until docker compose exec -T mongos mongosh --port 27017 --quiet --eval 'db.runCommand({ ping: 1 }).ok' >/dev/null 2>&1; do
+  sleep 1
+done
+
+docker compose exec -T configsvr mongosh --port 27019 --quiet <<'EOF'
+try {
+  rs.status()
+} catch (e) {
+  rs.initiate({
+    _id: "configReplSet",
+    configsvr: true,
+    members: [{ _id: 0, host: "configsvr:27019" }]
+  })
+}
+EOF
+
+docker compose exec -T shard1-1 mongosh --port 27018 --quiet <<'EOF'
+try {
+  rs.status()
+} catch (e) {
+  rs.initiate({
+    _id: "shard1ReplSet",
+    members: [
+      { _id: 0, host: "shard1-1:27018" },
+      { _id: 1, host: "shard1-2:27018" },
+      { _id: 2, host: "shard1-3:27018" }
+    ]
+  })
+}
+EOF
+
+docker compose exec -T shard2-1 mongosh --port 27018 --quiet <<'EOF'
+try {
+  rs.status()
+} catch (e) {
+  rs.initiate({
+    _id: "shard2ReplSet",
+    members: [
+      { _id: 0, host: "shard2-1:27018" },
+      { _id: 1, host: "shard2-2:27018" },
+      { _id: 2, host: "shard2-3:27018" }
+    ]
+  })
+}
+EOF
+
+docker compose exec -T mongos mongosh --port 27017 --quiet <<'EOF'
+try { sh.addShard("shard1ReplSet/shard1-1:27018,shard1-2:27018,shard1-3:27018") } catch (e) {}
+try { sh.addShard("shard2ReplSet/shard2-1:27018,shard2-2:27018,shard2-3:27018") } catch (e) {}
+try { sh.enableSharding("somedb") } catch (e) {}
+try { sh.shardCollection("somedb.helloDoc", { "_id": "hashed" }) } catch (e) {}
+EOF

--- a/mongo-sharding-repl/scripts/mongo-init.sh
+++ b/mongo-sharding-repl/scripts/mongo-init.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+###
+# Инициализируем бд
+###
+
+docker compose exec -T mongos mongosh --port 27017 --quiet <<EOF
+use somedb
+for(var i = 0; i < 1000; i++) db.helloDoc.insertOne({age:i, name:"ly"+i})
+EOF
+

--- a/mongo-sharding/README.md
+++ b/mongo-sharding/README.md
@@ -1,0 +1,39 @@
+# mongo-sharding
+
+Стенд с MongoDB шардированием на 2 шарда.
+
+## Запуск
+
+```bash
+docker compose up -d
+```
+
+## Инициализация кластера
+
+```bash
+chmod +x scripts/init-sharding.sh scripts/mongo-init.sh
+./scripts/init-sharding.sh
+./scripts/mongo-init.sh
+```
+
+## Проверка
+
+Проверить общее число документов:
+
+```bash
+docker compose exec -T mongos mongosh --port 27017 --quiet <<'EOF'
+use somedb
+db.helloDoc.countDocuments()
+EOF
+```
+
+Проверить распределение по шардам:
+
+```bash
+docker compose exec -T mongos mongosh --port 27017 --quiet <<'EOF'
+use somedb
+db.helloDoc.getShardDistribution()
+EOF
+```
+
+Приложение доступно на `http://localhost:8080`, документация на `http://localhost:8080/docs`.

--- a/mongo-sharding/api_app/Dockerfile
+++ b/mongo-sharding/api_app/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12.1-slim
+WORKDIR /app
+EXPOSE 8080
+COPY requirements.txt ./
+# Устанавливаем зависимости python не пересобирая их
+RUN pip install --no-cache --no-cache-dir -r requirements.txt
+# Копирование кода приложения
+COPY app.py /app/
+ENTRYPOINT ["uvicorn"]
+CMD ["app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/mongo-sharding/api_app/app.py
+++ b/mongo-sharding/api_app/app.py
@@ -1,0 +1,191 @@
+import json
+import logging
+import os
+import time
+from typing import List, Optional
+
+import motor.motor_asyncio
+from bson import ObjectId
+from fastapi import Body, FastAPI, HTTPException, status
+from fastapi_cache import FastAPICache
+from fastapi_cache.backends.redis import RedisBackend
+from fastapi_cache.decorator import cache
+from logmiddleware import RouterLoggingMiddleware, logging_config
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic.functional_validators import BeforeValidator
+from pymongo import errors
+from redis import asyncio as aioredis
+from typing_extensions import Annotated
+
+# Configure JSON logging
+logging.config.dictConfig(logging_config)
+logger = logging.getLogger(__name__)
+
+app = FastAPI()
+app.add_middleware(
+    RouterLoggingMiddleware,
+    logger=logger,
+)
+
+DATABASE_URL = os.environ["MONGODB_URL"]
+DATABASE_NAME = os.environ["MONGODB_DATABASE_NAME"]
+REDIS_URL = os.getenv("REDIS_URL", None)
+
+
+def nocache(*args, **kwargs):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+if REDIS_URL:
+    cache = cache
+else:
+    cache = nocache
+
+
+client = motor.motor_asyncio.AsyncIOMotorClient(DATABASE_URL)
+db = client[DATABASE_NAME]
+
+# Represents an ObjectId field in the database.
+# It will be represented as a `str` on the model so that it can be serialized to JSON.
+PyObjectId = Annotated[str, BeforeValidator(str)]
+
+
+@app.on_event("startup")
+async def startup():
+    if REDIS_URL:
+        redis = aioredis.from_url(REDIS_URL, encoding="utf8", decode_responses=True)
+        FastAPICache.init(RedisBackend(redis), prefix="api:cache")
+
+
+class UserModel(BaseModel):
+    """
+    Container for a single user record.
+    """
+
+    id: Optional[PyObjectId] = Field(alias="_id", default=None)
+    age: int = Field(...)
+    name: str = Field(...)
+
+
+class UserCollection(BaseModel):
+    """
+    A container holding a list of `UserModel` instances.
+    """
+
+    users: List[UserModel]
+
+
+@app.get("/")
+async def root():
+    collection_names = await db.list_collection_names()
+    collections = {}
+    for collection_name in collection_names:
+        collection = db.get_collection(collection_name)
+        collections[collection_name] = {
+            "documents_count": await collection.count_documents({})
+        }
+    try:
+        replica_status = await client.admin.command("replSetGetStatus")
+        replica_status = json.dumps(replica_status, indent=2, default=str)
+    except errors.OperationFailure:
+        replica_status = "No Replicas"
+
+    topology_description = client.topology_description
+    read_preference = client.client_options.read_preference
+    topology_type = topology_description.topology_type_name
+    replicaset_name = topology_description.replica_set_name
+
+    shards = None
+    if topology_type == "Sharded":
+        shards_list = await client.admin.command("listShards")
+        shards = {}
+        for shard in shards_list.get("shards", {}):
+            shards[shard["_id"]] = shard["host"]
+
+    cache_enabled = False
+    if REDIS_URL:
+        cache_enabled = FastAPICache.get_enable()
+
+    return {
+        "mongo_topology_type": topology_type,
+        "mongo_replicaset_name": replicaset_name,
+        "mongo_db": DATABASE_NAME,
+        "read_preference": str(read_preference),
+        "mongo_nodes": client.nodes,
+        "mongo_primary_host": client.primary,
+        "mongo_secondary_hosts": client.secondaries,
+        "mongo_is_primary": client.is_primary,
+        "mongo_is_mongos": client.is_mongos,
+        "collections": collections,
+        "shards": shards,
+        "cache_enabled": cache_enabled,
+        "status": "OK",
+    }
+
+
+@app.get("/{collection_name}/count")
+async def collection_count(collection_name: str):
+    collection = db.get_collection(collection_name)
+    items_count = await collection.count_documents({})
+    # status = await client.admin.command('replSetGetStatus')
+    # import ipdb; ipdb.set_trace()
+    return {"status": "OK", "mongo_db": DATABASE_NAME, "items_count": items_count}
+
+
+@app.get(
+    "/{collection_name}/users",
+    response_description="List all users",
+    response_model=UserCollection,
+    response_model_by_alias=False,
+)
+@cache(expire=60 * 1)
+async def list_users(collection_name: str):
+    """
+    List all of the user data in the database.
+    The response is unpaginated and limited to 1000 results.
+    """
+    time.sleep(1)
+    collection = db.get_collection(collection_name)
+    return UserCollection(users=await collection.find().to_list(1000))
+
+
+@app.get(
+    "/{collection_name}/users/{name}",
+    response_description="Get a single user",
+    response_model=UserModel,
+    response_model_by_alias=False,
+)
+async def show_user(collection_name: str, name: str):
+    """
+    Get the record for a specific user, looked up by `name`.
+    """
+
+    collection = db.get_collection(collection_name)
+    if (user := await collection.find_one({"name": name})) is not None:
+        return user
+
+    raise HTTPException(status_code=404, detail=f"User {name} not found")
+
+
+@app.post(
+    "/{collection_name}/users",
+    response_description="Add new user",
+    response_model=UserModel,
+    status_code=status.HTTP_201_CREATED,
+    response_model_by_alias=False,
+)
+async def create_user(collection_name: str, user: UserModel = Body(...)):
+    """
+    Insert a new user record.
+
+    A unique `id` will be created and provided in the response.
+    """
+    collection = db.get_collection(collection_name)
+    new_user = await collection.insert_one(
+        user.model_dump(by_alias=True, exclude=["id"])
+    )
+    created_user = await collection.find_one({"_id": new_user.inserted_id})
+    return created_user

--- a/mongo-sharding/api_app/requirements.txt
+++ b/mongo-sharding/api_app/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.110.2
+uvicorn[standard]==0.29.0
+motor==3.5.3
+redis==4.4.2
+fastapi-cache2==0.2.0
+logmiddleware==0.0.4

--- a/mongo-sharding/compose.yaml
+++ b/mongo-sharding/compose.yaml
@@ -1,0 +1,50 @@
+name: mongo-sharding
+
+services:
+  configsvr:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: configsvr
+    command: mongod --configsvr --replSet configReplSet --port 27019
+    volumes:
+      - configsvr_data:/data/db
+
+  shard1:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: shard1
+    command: mongod --shardsvr --replSet shard1ReplSet --port 27018
+    volumes:
+      - shard1_data:/data/db
+
+  shard2:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: shard2
+    command: mongod --shardsvr --replSet shard2ReplSet --port 27018
+    volumes:
+      - shard2_data:/data/db
+
+  mongos:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: mongos
+    command: mongos --configdb configReplSet/configsvr:27019 --bind_ip_all --port 27017
+    depends_on:
+      - configsvr
+      - shard1
+      - shard2
+    ports:
+      - "27017:27017"
+
+  pymongo_api:
+    image: kazhem/pymongo_api:1.0.0
+    container_name: pymongo_api
+    depends_on:
+      - mongos
+    ports:
+      - "8080:8080"
+    environment:
+      MONGODB_URL: "mongodb://mongos:27017"
+      MONGODB_DATABASE_NAME: "somedb"
+
+volumes:
+  configsvr_data:
+  shard1_data:
+  shard2_data:

--- a/mongo-sharding/scripts/init-sharding.sh
+++ b/mongo-sharding/scripts/init-sharding.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+until docker compose exec -T mongos mongosh --port 27017 --quiet --eval 'db.runCommand({ ping: 1 }).ok' >/dev/null 2>&1; do
+  sleep 1
+done
+
+docker compose exec -T configsvr mongosh --port 27019 --quiet <<'EOF'
+try {
+  rs.status()
+} catch (e) {
+  rs.initiate({
+    _id: "configReplSet",
+    configsvr: true,
+    members: [{ _id: 0, host: "configsvr:27019" }]
+  })
+}
+EOF
+
+docker compose exec -T shard1 mongosh --port 27018 --quiet <<'EOF'
+try {
+  rs.status()
+} catch (e) {
+  rs.initiate({
+    _id: "shard1ReplSet",
+    members: [{ _id: 0, host: "shard1:27018" }]
+  })
+}
+EOF
+
+docker compose exec -T shard2 mongosh --port 27018 --quiet <<'EOF'
+try {
+  rs.status()
+} catch (e) {
+  rs.initiate({
+    _id: "shard2ReplSet",
+    members: [{ _id: 0, host: "shard2:27018" }]
+  })
+}
+EOF
+
+docker compose exec -T mongos mongosh --port 27017 --quiet <<'EOF'
+try { sh.addShard("shard1ReplSet/shard1:27018") } catch (e) {}
+try { sh.addShard("shard2ReplSet/shard2:27018") } catch (e) {}
+try { sh.enableSharding("somedb") } catch (e) {}
+try { sh.shardCollection("somedb.helloDoc", { "_id": "hashed" }) } catch (e) {}
+EOF

--- a/mongo-sharding/scripts/mongo-init.sh
+++ b/mongo-sharding/scripts/mongo-init.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+###
+# Инициализируем бд
+###
+
+docker compose exec -T mongos mongosh --port 27017 --quiet <<EOF
+use somedb
+for(var i = 0; i < 1000; i++) db.helloDoc.insertOne({age:i, name:"ly"+i})
+EOF
+

--- a/sharding-repl-cache/README.md
+++ b/sharding-repl-cache/README.md
@@ -1,0 +1,52 @@
+# sharding-repl-cache
+
+Финальный стенд для проверки (шардирование + репликация + Redis кеш).
+
+## Запуск
+
+```bash
+docker compose up -d
+```
+
+## Инициализация MongoDB
+
+```bash
+chmod +x scripts/init-repl-sharding.sh scripts/mongo-init.sh
+./scripts/init-repl-sharding.sh
+./scripts/mongo-init.sh
+```
+
+## Проверка MongoDB
+
+Общее количество документов (должно быть >= 1000):
+
+```bash
+docker compose exec -T mongos mongosh --port 27017 --quiet <<'EOF'
+use somedb
+db.helloDoc.countDocuments()
+EOF
+```
+
+Проверка шардов и реплик:
+
+```bash
+docker compose exec -T mongos mongosh --port 27017 --quiet <<'EOF'
+sh.status()
+EOF
+```
+
+## Проверка кеша
+
+Первый вызов будет медленнее, повторные должны быть быстрее:
+
+```bash
+time curl -s http://localhost:8080/helloDoc/users > /dev/null
+time curl -s http://localhost:8080/helloDoc/users > /dev/null
+```
+
+Второй и следующие вызовы должны быть меньше 100ms.
+
+## Полезные ссылки
+
+- API: `http://localhost:8080`
+- Swagger: `http://localhost:8080/docs`

--- a/sharding-repl-cache/api_app/Dockerfile
+++ b/sharding-repl-cache/api_app/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12.1-slim
+WORKDIR /app
+EXPOSE 8080
+COPY requirements.txt ./
+# Устанавливаем зависимости python не пересобирая их
+RUN pip install --no-cache --no-cache-dir -r requirements.txt
+# Копирование кода приложения
+COPY app.py /app/
+ENTRYPOINT ["uvicorn"]
+CMD ["app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/sharding-repl-cache/api_app/app.py
+++ b/sharding-repl-cache/api_app/app.py
@@ -1,0 +1,191 @@
+import json
+import logging
+import os
+import time
+from typing import List, Optional
+
+import motor.motor_asyncio
+from bson import ObjectId
+from fastapi import Body, FastAPI, HTTPException, status
+from fastapi_cache import FastAPICache
+from fastapi_cache.backends.redis import RedisBackend
+from fastapi_cache.decorator import cache
+from logmiddleware import RouterLoggingMiddleware, logging_config
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic.functional_validators import BeforeValidator
+from pymongo import errors
+from redis import asyncio as aioredis
+from typing_extensions import Annotated
+
+# Configure JSON logging
+logging.config.dictConfig(logging_config)
+logger = logging.getLogger(__name__)
+
+app = FastAPI()
+app.add_middleware(
+    RouterLoggingMiddleware,
+    logger=logger,
+)
+
+DATABASE_URL = os.environ["MONGODB_URL"]
+DATABASE_NAME = os.environ["MONGODB_DATABASE_NAME"]
+REDIS_URL = os.getenv("REDIS_URL", None)
+
+
+def nocache(*args, **kwargs):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+if REDIS_URL:
+    cache = cache
+else:
+    cache = nocache
+
+
+client = motor.motor_asyncio.AsyncIOMotorClient(DATABASE_URL)
+db = client[DATABASE_NAME]
+
+# Represents an ObjectId field in the database.
+# It will be represented as a `str` on the model so that it can be serialized to JSON.
+PyObjectId = Annotated[str, BeforeValidator(str)]
+
+
+@app.on_event("startup")
+async def startup():
+    if REDIS_URL:
+        redis = aioredis.from_url(REDIS_URL, encoding="utf8", decode_responses=True)
+        FastAPICache.init(RedisBackend(redis), prefix="api:cache")
+
+
+class UserModel(BaseModel):
+    """
+    Container for a single user record.
+    """
+
+    id: Optional[PyObjectId] = Field(alias="_id", default=None)
+    age: int = Field(...)
+    name: str = Field(...)
+
+
+class UserCollection(BaseModel):
+    """
+    A container holding a list of `UserModel` instances.
+    """
+
+    users: List[UserModel]
+
+
+@app.get("/")
+async def root():
+    collection_names = await db.list_collection_names()
+    collections = {}
+    for collection_name in collection_names:
+        collection = db.get_collection(collection_name)
+        collections[collection_name] = {
+            "documents_count": await collection.count_documents({})
+        }
+    try:
+        replica_status = await client.admin.command("replSetGetStatus")
+        replica_status = json.dumps(replica_status, indent=2, default=str)
+    except errors.OperationFailure:
+        replica_status = "No Replicas"
+
+    topology_description = client.topology_description
+    read_preference = client.client_options.read_preference
+    topology_type = topology_description.topology_type_name
+    replicaset_name = topology_description.replica_set_name
+
+    shards = None
+    if topology_type == "Sharded":
+        shards_list = await client.admin.command("listShards")
+        shards = {}
+        for shard in shards_list.get("shards", {}):
+            shards[shard["_id"]] = shard["host"]
+
+    cache_enabled = False
+    if REDIS_URL:
+        cache_enabled = FastAPICache.get_enable()
+
+    return {
+        "mongo_topology_type": topology_type,
+        "mongo_replicaset_name": replicaset_name,
+        "mongo_db": DATABASE_NAME,
+        "read_preference": str(read_preference),
+        "mongo_nodes": client.nodes,
+        "mongo_primary_host": client.primary,
+        "mongo_secondary_hosts": client.secondaries,
+        "mongo_is_primary": client.is_primary,
+        "mongo_is_mongos": client.is_mongos,
+        "collections": collections,
+        "shards": shards,
+        "cache_enabled": cache_enabled,
+        "status": "OK",
+    }
+
+
+@app.get("/{collection_name}/count")
+async def collection_count(collection_name: str):
+    collection = db.get_collection(collection_name)
+    items_count = await collection.count_documents({})
+    # status = await client.admin.command('replSetGetStatus')
+    # import ipdb; ipdb.set_trace()
+    return {"status": "OK", "mongo_db": DATABASE_NAME, "items_count": items_count}
+
+
+@app.get(
+    "/{collection_name}/users",
+    response_description="List all users",
+    response_model=UserCollection,
+    response_model_by_alias=False,
+)
+@cache(expire=60 * 1)
+async def list_users(collection_name: str):
+    """
+    List all of the user data in the database.
+    The response is unpaginated and limited to 1000 results.
+    """
+    time.sleep(1)
+    collection = db.get_collection(collection_name)
+    return UserCollection(users=await collection.find().to_list(1000))
+
+
+@app.get(
+    "/{collection_name}/users/{name}",
+    response_description="Get a single user",
+    response_model=UserModel,
+    response_model_by_alias=False,
+)
+async def show_user(collection_name: str, name: str):
+    """
+    Get the record for a specific user, looked up by `name`.
+    """
+
+    collection = db.get_collection(collection_name)
+    if (user := await collection.find_one({"name": name})) is not None:
+        return user
+
+    raise HTTPException(status_code=404, detail=f"User {name} not found")
+
+
+@app.post(
+    "/{collection_name}/users",
+    response_description="Add new user",
+    response_model=UserModel,
+    status_code=status.HTTP_201_CREATED,
+    response_model_by_alias=False,
+)
+async def create_user(collection_name: str, user: UserModel = Body(...)):
+    """
+    Insert a new user record.
+
+    A unique `id` will be created and provided in the response.
+    """
+    collection = db.get_collection(collection_name)
+    new_user = await collection.insert_one(
+        user.model_dump(by_alias=True, exclude=["id"])
+    )
+    created_user = await collection.find_one({"_id": new_user.inserted_id})
+    return created_user

--- a/sharding-repl-cache/api_app/requirements.txt
+++ b/sharding-repl-cache/api_app/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.110.2
+uvicorn[standard]==0.29.0
+motor==3.5.3
+redis==4.4.2
+fastapi-cache2==0.2.0
+logmiddleware==0.0.4

--- a/sharding-repl-cache/compose.yaml
+++ b/sharding-repl-cache/compose.yaml
@@ -1,0 +1,94 @@
+name: sharding-repl-cache
+
+services:
+  configsvr:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: configsvr
+    command: mongod --configsvr --replSet configReplSet --port 27019
+    volumes:
+      - configsvr_data:/data/db
+
+  shard1-1:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: shard1-1
+    command: mongod --shardsvr --replSet shard1ReplSet --port 27018
+    volumes:
+      - shard1_1_data:/data/db
+
+  shard1-2:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: shard1-2
+    command: mongod --shardsvr --replSet shard1ReplSet --port 27018
+    volumes:
+      - shard1_2_data:/data/db
+
+  shard1-3:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: shard1-3
+    command: mongod --shardsvr --replSet shard1ReplSet --port 27018
+    volumes:
+      - shard1_3_data:/data/db
+
+  shard2-1:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: shard2-1
+    command: mongod --shardsvr --replSet shard2ReplSet --port 27018
+    volumes:
+      - shard2_1_data:/data/db
+
+  shard2-2:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: shard2-2
+    command: mongod --shardsvr --replSet shard2ReplSet --port 27018
+    volumes:
+      - shard2_2_data:/data/db
+
+  shard2-3:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: shard2-3
+    command: mongod --shardsvr --replSet shard2ReplSet --port 27018
+    volumes:
+      - shard2_3_data:/data/db
+
+  mongos:
+    image: dh-mirror.gitverse.ru/mongo:latest
+    container_name: mongos
+    command: mongos --configdb configReplSet/configsvr:27019 --bind_ip_all --port 27017
+    depends_on:
+      - configsvr
+      - shard1-1
+      - shard1-2
+      - shard1-3
+      - shard2-1
+      - shard2-2
+      - shard2-3
+    ports:
+      - "27017:27017"
+
+  redis:
+    image: dh-mirror.gitverse.ru/redis:7-alpine
+    container_name: redis
+    ports:
+      - "6379:6379"
+
+  pymongo_api:
+    image: kazhem/pymongo_api:1.0.0
+    container_name: pymongo_api
+    depends_on:
+      - mongos
+      - redis
+    ports:
+      - "8080:8080"
+    environment:
+      MONGODB_URL: "mongodb://mongos:27017"
+      MONGODB_DATABASE_NAME: "somedb"
+      REDIS_URL: "redis://redis:6379"
+
+volumes:
+  configsvr_data:
+  shard1_1_data:
+  shard1_2_data:
+  shard1_3_data:
+  shard2_1_data:
+  shard2_2_data:
+  shard2_3_data:

--- a/sharding-repl-cache/scripts/init-repl-sharding.sh
+++ b/sharding-repl-cache/scripts/init-repl-sharding.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+until docker compose exec -T mongos mongosh --port 27017 --quiet --eval 'db.runCommand({ ping: 1 }).ok' >/dev/null 2>&1; do
+  sleep 1
+done
+
+docker compose exec -T configsvr mongosh --port 27019 --quiet <<'EOF'
+try {
+  rs.status()
+} catch (e) {
+  rs.initiate({
+    _id: "configReplSet",
+    configsvr: true,
+    members: [{ _id: 0, host: "configsvr:27019" }]
+  })
+}
+EOF
+
+docker compose exec -T shard1-1 mongosh --port 27018 --quiet <<'EOF'
+try {
+  rs.status()
+} catch (e) {
+  rs.initiate({
+    _id: "shard1ReplSet",
+    members: [
+      { _id: 0, host: "shard1-1:27018" },
+      { _id: 1, host: "shard1-2:27018" },
+      { _id: 2, host: "shard1-3:27018" }
+    ]
+  })
+}
+EOF
+
+docker compose exec -T shard2-1 mongosh --port 27018 --quiet <<'EOF'
+try {
+  rs.status()
+} catch (e) {
+  rs.initiate({
+    _id: "shard2ReplSet",
+    members: [
+      { _id: 0, host: "shard2-1:27018" },
+      { _id: 1, host: "shard2-2:27018" },
+      { _id: 2, host: "shard2-3:27018" }
+    ]
+  })
+}
+EOF
+
+docker compose exec -T mongos mongosh --port 27017 --quiet <<'EOF'
+try { sh.addShard("shard1ReplSet/shard1-1:27018,shard1-2:27018,shard1-3:27018") } catch (e) {}
+try { sh.addShard("shard2ReplSet/shard2-1:27018,shard2-2:27018,shard2-3:27018") } catch (e) {}
+try { sh.enableSharding("somedb") } catch (e) {}
+try { sh.shardCollection("somedb.helloDoc", { "_id": "hashed" }) } catch (e) {}
+EOF

--- a/sharding-repl-cache/scripts/mongo-init.sh
+++ b/sharding-repl-cache/scripts/mongo-init.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+###
+# Инициализируем бд
+###
+
+docker compose exec -T mongos mongosh --port 27017 --quiet <<EOF
+use somedb
+for(var i = 0; i < 1000; i++) db.helloDoc.insertOne({age:i, name:"ly"+i})
+EOF
+


### PR DESCRIPTION
## Что сделано

В работе три последовательных этапа в отдельных каталогах: сначала шардирование MongoDB (`mongo-sharding`), затем с репликацией (`mongo-sharding-repl`), затем с Redis (`sharding-repl-cache`). Для финального варианта: два шарда, на каждом по трём узлам в replica set, плюс кеш — приложение берёт `REDIS_URL`.

В корне обновил `README.md`: как поднять окружение, прогнать инициализацию и что проверить глазами. Добавил итоговую схему в `architecture-final.drawio`.

## Как можно проверить

- В каждой из трёх папок с этапами `docker compose config` проходит без ошибок.
- В `sharding-repl-cache` стек поднимается, скрипты создают replica set’ы, включают шардирование и заливают не меньше 1000 документов.
- Видно, что данные уходят на шарды и по три члена репликации на шард.
- На кеш: второй запрос к `/helloDoc/users` укладывается примерно в 100 ms (после прогрева).

Если что-то отваливается при поднятии — напишите, разберёмся.